### PR TITLE
WIP: Override open-uri to archive scraped pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem "colorize"
 gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
+gem 'scraped_page_archive', git: 'https://github.com/everypolitician/scraped_page_archive', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/everypolitician/scraped_page_archive
-  revision: 19a2a2f842920ad5fbabb984310e8ea72912d3ba
+  revision: 4d8871832e8bff307cd927d123e6ef93ee29973c
   branch: master
   specs:
     scraped_page_archive (0.1.0)
-      open-uri-cached
+      vcr-archive (>= 0.2.0)
 
 GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
@@ -18,10 +18,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     execjs (2.5.2)
     fuzzy_match (2.1.0)
+    hashdiff (0.3.0)
     httpclient (2.6.0.1)
     method_source (0.8.2)
     mini_portile (0.6.2)
@@ -32,10 +36,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.2.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive
+  revision: 19a2a2f842920ad5fbabb984310e8ea72912d3ba
+  branch: master
+  specs:
+    scraped_page_archive (0.1.0)
+      open-uri-cached
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -39,4 +47,11 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
+
+RUBY VERSION
+   ruby 2.0.0p353
+
+BUNDLED WITH
+   1.12.4

--- a/scraper.rb
+++ b/scraper.rb
@@ -87,8 +87,22 @@ class Riigikogu
       noko.css('.icon-mail').xpath('../text()').text
     end
 
+    def facebook
+      social_media.css('a.facebook/@href').text
+    end
+
+    def twitter
+      social_media.css('a.twitter/@href').text
+    end
+
     def source
       url
+    end
+
+
+    private
+    def social_media
+      noko.xpath('//h2[.="Sotsiaalmeedia"]/following-sibling::div[@class="group"]')
     end
 
   end
@@ -97,6 +111,5 @@ end
 liikmed = Riigikogu::Liikmed.new('http://www.riigikogu.ee/riigikogu/koosseis/riigikogu-liikmed/').as_data
 liikmed[:members].each do |member|
   data = Riigikogu::Saadik.new(member[:url]).as_data
-  warn data
   ScraperWiki.save_sqlite([:id], data)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,6 +8,8 @@ require 'colorize'
 require 'scraped_page_archive'
 
 require 'pry'
+require 'open-uri/cached'
+OpenURI::Cache.cache_path = '.cache'
 
 class String
   def tidy

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,85 +5,13 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'open-uri'
 require 'colorize'
+require 'scraped_page_archive'
 
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
 
 class String
   def tidy
     self.gsub(/[[:space:]]+/, ' ').strip
-  end
-end
-
-require 'singleton'
-module ScraperArchive
-  class GitBranchCache
-    include Singleton
-
-    attr_writer :github_repo_url
-
-    def cache_response(url)
-      clone_repo_if_missing!
-      Dir.chdir(archive_directory) do
-        create_or_checkout_archive_branch!
-        OpenURI::Cache.cache_path = archive_directory
-        response = yield(url)
-        message = "#{response.status.join(' ')} #{url}"
-        system("git add .")
-        system("git commit --allow-empty --message='#{message}'")
-        system("git push origin #{branch_name}")
-        response
-      end
-    end
-
-    def clone_repo_if_missing!
-      unless File.directory?(archive_directory)
-        warn "Cloning archive repo into /tmp"
-        system("git clone #{github_repo_url} #{archive_directory}")
-      end
-    end
-
-    def create_or_checkout_archive_branch!
-      if system("git rev-parse --verify #{branch_name} > /dev/null 2>&1")
-        system("git checkout --quiet -B #{branch_name}")
-      else
-        system("git checkout --orphan #{branch_name}")
-        system("git rm --quiet -rf .")
-      end
-    end
-
-    def github_repo_url
-      @github_repo_url ||= ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL']
-    end
-
-    # TODO: This should be configurable
-    def refresh_cache?
-      true
-    end
-
-    # TODO: This should be configurable
-    def archive_directory
-      @archive_directory ||= '/tmp/scraper-archive'
-    end
-
-    # TODO: This should be configurable
-    def branch_name
-      @branch_name ||= 'scraped-pages-archive'
-    end
-  end
-end
-
-ScraperArchive::GitBranchCache.instance.github_repo_url = 'https://github.com/tmtmtmtm/estonia-riigikogu'
-
-module OpenURI
-  class << self
-    alias __open_uri open_uri
-    def open_uri(url, *args)
-      ScraperArchive::GitBranchCache.instance.cache_response(url) do |*open_uri_args|
-        __open_uri(*open_uri_args)
-      end
-    end
   end
 end
 


### PR DESCRIPTION
This is _very much_ a work in progress. This is the simplest version to prove the idea works. The result of running this can be on the [scraped-pages-archive branch](https://github.com/tmtmtmtm/estonia-riigikogu/tree/scraped-pages-archive/www.riigikogu.ee).
- [x] Create an orphan branch rather than a branch off `master`
- [x] Don't hardcode the repo name
- [x] Don't hardcode the branch name
- [x] Pull this logic into a testable class that can be called from the overridden `open` method.

Part of https://github.com/everypolitician/everypolitician/issues/466
